### PR TITLE
Map Colour: Remove CSS style instead of rewriting to white

### DIFF
--- a/MH - Consolidated Map Colour Coder.user.js
+++ b/MH - Consolidated Map Colour Coder.user.js
@@ -85,7 +85,7 @@ function colourise(){
     var allList = $(".treasureMapView-goals-group-goal")
     //Reset to white background
     for (var a=0;a<allList.length;a++){
-        allList[a].style.backgroundColor = "white"
+        allList[a].style.removeProperty("backgroundColor");
     };
     var caughtList = [];
     var uncaughtList = [];
@@ -559,8 +559,8 @@ function settings(){
                         }
                     }));
                 } else if (current.indexOf(mouseName)>=0){
-                    this.style.backgroundColor = "white";
-                    this.style.fontWeight = "";
+                    this.style.removeProperty("backgroundColor");
+                    this.style.removeProperty("fontWeight");
                     var x = current.indexOf(mouseName);
                     current.splice(x,1);
                     if (target.children.length !== 0){

--- a/MH - Consolidated Map Colour Coder.user.js
+++ b/MH - Consolidated Map Colour Coder.user.js
@@ -2,7 +2,7 @@
 // @name         MH - Consolidated Map Colour Coder
 // @description  Colour code your maps
 // @author       Chromatical
-// @version      1.2.11
+// @version      1.2.12
 // @match        https://www.mousehuntgame.com/*
 // @match        https://apps.facebook.com/mousehunt/*
 // @icon         https://www.google.com/s2/favicons?domain=mousehuntgame.com


### PR DESCRIPTION
Instead of assigning the background to white, just remove the added color instead. This is more compatible with dark mode scripts/extensions.